### PR TITLE
refactor: :technologist: Better error message when ASSET is used in a function

### DIFF
--- a/include/hot-cold-asset/asset.hpp
+++ b/include/hot-cold-asset/asset.hpp
@@ -16,7 +16,7 @@ typedef struct __attribute__((__packed__)) _asset {
 
 #define ASSET(x)                                                               \
   static_assert(!__builtin_strcmp(__FUNCTION__, "top level"),                  \
-    "Cannot use ASSET inside a function!");                                    \
+                "Cannot use ASSET inside a function!");                        \
   extern "C" {                                                                 \
   extern uint8_t _binary_static_##x##_start[], _binary_static_##x##_size[];    \
   static asset x = {_binary_static_##x##_start,                                \
@@ -25,7 +25,7 @@ typedef struct __attribute__((__packed__)) _asset {
 
 #define ASSET_LIB(x)                                                           \
   static_assert(!__builtin_strcmp(__FUNCTION__, "top level"),                  \
-    "Cannot use ASSET_LIB inside a function!");                                \
+                "Cannot use ASSET_LIB inside a function!");                    \
   extern "C" {                                                                 \
   extern uint8_t _binary_static_lib_##x##_start[],                             \
       _binary_static_lib_##x##_size[];                                         \

--- a/include/hot-cold-asset/asset.hpp
+++ b/include/hot-cold-asset/asset.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #ifndef _ASSET_H_
@@ -14,6 +15,8 @@ typedef struct __attribute__((__packed__)) _asset {
 }
 
 #define ASSET(x)                                                               \
+  static_assert(!__builtin_strcmp(__FUNCTION__, "top level"),                  \
+    "Cannot use ASSET inside a function!");                                    \
   extern "C" {                                                                 \
   extern uint8_t _binary_static_##x##_start[], _binary_static_##x##_size[];    \
   static asset x = {_binary_static_##x##_start,                                \
@@ -21,6 +24,8 @@ typedef struct __attribute__((__packed__)) _asset {
   }
 
 #define ASSET_LIB(x)                                                           \
+  static_assert(!__builtin_strcmp(__FUNCTION__, "top level"),                  \
+    "Cannot use ASSET_LIB inside a function!");                                \
   extern "C" {                                                                 \
   extern uint8_t _binary_static_lib_##x##_start[],                             \
       _binary_static_lib_##x##_size[];                                         \


### PR DESCRIPTION
Adds a static assert so that users get a better error message when using ASSET inside of a function (right now the compiler spits out a parsing error that gives no indication of the actual issue).
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: fe10a8eb28aead6e945563716e1cc30225c6576f -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/hot-cold-asset/actions/runs/12127705587)
- via manual download: [hot-cold-asset@1.0.0+a6cad1.zip](https://nightly.link/LemLib/hot-cold-asset/actions/artifacts/2263848638.zip)
- via PROS Integrated Terminal: 
 ```
curl -o hot-cold-asset@1.0.0+a6cad1.zip https://nightly.link/LemLib/hot-cold-asset/actions/artifacts/2263848638.zip;
pros c fetch hot-cold-asset@1.0.0+a6cad1.zip;
pros c apply hot-cold-asset@1.0.0+a6cad1;
rm hot-cold-asset@1.0.0+a6cad1.zip;
```